### PR TITLE
[REF] .travis.yml: Enable new arch of travis, use oca_dependencies.txt and include unitest of addons-vauxoo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,57 @@
 language: python
 
-build_image: vauxoo/odoo-80-image-shippable-auto
-commit_container: cowardvassal/vauxoo-dev
+sudo: false
+cache:
+  apt: true
+  directories:
+    - $HOME/.pip-cache/
+
+addons:
+  apt:
+    sources:
+      - pov-wkhtmltopdf
+    packages:
+      - expect-dev
+      - python-lxml
+      - python-simplejson
+      - python-yaml
+      - wkhtmltopdf
+      - swig  # Required for m2crypto
+      - python-m2crypto
+      - xmlstarlet
+      - xsltproc
+      - xmlstarlet
+      - openssl
+      - poppler-utils
+      - antiword
+      - python-libxml2
+
+# set up an X server to run wkhtmltopdf.
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 
 python:
   - "2.7"
-
 env:
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" INCLUDE="ovl_all"
+  global:
+  - TEST_OTHER_PROJECTS=${HOME}/addons-vauxoo LINT_CHECK=0 TESTS="0" VERSION="7.0" ODOO_REPO="vauxoo/odoo" INCLUDE="ovl_all"
+
+  matrix:
+  - LINT_CHECK=1
+  - TESTS="1"
 
 virtualenv:
   system_site_packages: true
 
 install:
-  - git clone https://github.com/vauxoo/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
+  - git clone --single-branch --depth=1 https://github.com/vauxoo/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - ${TRAVIS_BUILD_DIR}/travis/travis_install_ve_nightly ${VERSION}
-  - git clone --single-branch --depth=1 https://github.com/Vauxoo/addons-vauxoo.git -b ${VERSION} ${HOME}/addons-vauxoo
 
 script:
-  - travis_run_tests
+  - travis_wait travis_run_tests
 
 after_success:
-  coveralls
+  - travis_after_tests_success

--- a/l10n_ve_split_invoice/model/invoice.py
+++ b/l10n_ve_split_invoice/model/invoice.py
@@ -81,7 +81,7 @@ class account_invoice(osv.osv):
                         cont += 1
                     for il in lst:
                         self.pool.get('account.invoice.line').write(
-                            cr, uid, il.id, {'invoice_id': inv_id})
+                            cr, uid, [il.id], {'invoice_id': inv_id})
                     self.button_compute(cr, uid, [inv.id], set_total=True)
             if inv_id:
                 self.button_compute(cr, uid, [inv_id], set_total=True)

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+addons-vauxoo https://github.com/Vauxoo/addons-vauxoo.git

--- a/travis/travis_install_ve_nightly
+++ b/travis/travis_install_ve_nightly
@@ -3,22 +3,21 @@
 set -v
 
 ##VE PACKAGES
-sudo apt-get install python-libxml2
+apt-get install python-libxml2
 
 ##ADDONS-VAUXOO PACKAGES#FIXME: This modules make error use or not use it
-sudo pip install recaptcha-client egenix-mx-base
+pip install recaptcha-client egenix-mx-base
 
 ##ODOO PACKAGES#FIXME: This package should be within the main script
-sudo pip install PyWebDAV mygengo
+pip install PyWebDAV mygengo
 #sudo apt-get install pdftotext antiword
-sudo apt-get install poppler-utils # pdftotext is here
-sudo apt-get install antiword
+apt-get install poppler-utils # pdftotext is here
+apt-get install antiword
 
+# Deprecated with sudo: false and packages in travis-ci. Commented FYI of local installation
 # Install webkit and patched process
-sudo apt-get install wkhtmltopdf
-mkdir -p /tmp/webkit_patched
-wget -O /tmp/webkit_patched/wkhtmltopdf.tar.bz2 https://wkhtmltopdf.googlecode.com/files/wkhtmltopdf-0.11.0_rc1-static-amd64.tar.bz2
-bzip2 -dc /tmp/webkit_patched/wkhtmltopdf.tar.bz2 | tar -xvO >/tmp/webkit_patched/webkit-patched
-sudo cp /tmp/webkit_patched/webkit-patched /usr/bin/wkhtmltopdf
+# apt-get install libxfont1 xfonts-utils xfonts-75dpi xfonts-base xfonts-encodings
+# wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb -O wk.deb
+# dpkg -i wk.deb
 
 exit 0


### PR DESCRIPTION
- Split lint test and unittest
- Use of new arch of travis app
- Include unittest of modules used from `addons-vauxoo`
